### PR TITLE
Update colors.py

### DIFF
--- a/treescore/judge/colors.py
+++ b/treescore/judge/colors.py
@@ -63,7 +63,7 @@ class RegressionColorPicker(object):
     """ColorPicker based on logistic regression model"""
 
     def __init__(self, model=None):
-        self.model = model or sklearn.LogisticRegression()
+        self.model = model or LogisticRegression()
 
     @classmethod
     def from_file(cls, fname):


### PR DESCRIPTION
Fixed the no-model-supplied case for RegressionColorPicker (it has already been imported from sklearn - but sklearn has not itself been imported and throws an error).

As an aside: could you upload your model.data file for use? It's not included in the repo and it means your example doesn't work :-)
